### PR TITLE
Return reader instead of Weka Instances for improved memory footprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,9 @@
 /dist
 /doc
 /data
-/target/
+/target
+
+
+*.class
+*.log
+.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Running the tests
+The tests depend on the test.openml.org server. In the `BaseTestFramework` the api keys are defined of a couple of 
+users. The `client_write_test` and `client_admin_test` do not have write / admin privileges on the test.openml.org 
+server. Ideally we'd fix this by mocking the responses of the test-server.
+
+Because this repo isn't very actively developed, I've quickly fixed this for now by giving temporary write/admin access 
+to these api_keys. These commands can be used:
+```sql
+USE openml;
+SELECT id FROM users WHERE session_hash = "[API_KEY]";
+INSERT INTO users_groups (user_id, group_id) VALUES ([USER_ID_ADMIN], 1);  # admin access
+INSERT INTO users_groups (user_id, group_id) VALUES ([USER_ID_WRITE], 2);  # member access
+```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.openml</groupId>
   <artifactId>openmlweka</artifactId>
-  <version>0.9.8-SNAPSHOT</version>
+  <version>0.9.9-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>OpenmlWeka</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.openml</groupId>
   <artifactId>openmlweka</artifactId>
-  <version>0.9.9-SNAPSHOT</version>
+  <version>0.9.10-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>OpenmlWeka</name>

--- a/src/main/java/org/openml/weka/io/OpenmlWekaConnector.java
+++ b/src/main/java/org/openml/weka/io/OpenmlWekaConnector.java
@@ -1,7 +1,9 @@
 package org.openml.weka.io;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -27,7 +29,9 @@ public class OpenmlWekaConnector extends OpenmlConnector {
 	}
 	
 	/**
-	 * Downloads a dataset from OpenML and parses it as Instances object
+	 * Open a http connection to a openML dataset file and return a file reader.
+	 * The resulting file reader can be wrapped by a Weka ArffReader. Alternatively, it can be wrapped by a Weka
+	 * Instances object, in which case the complete file will be read into memory.
 	 * 
 	 * @param dsd - the data set description object, as downloaded from openml
 	 * @return the dataset file parsed as arff
@@ -35,13 +39,15 @@ public class OpenmlWekaConnector extends OpenmlConnector {
 	 * 					   parsing exception when the file id is not
 	 *                     valid arff
 	 */
-	public Instances getDataset(DataSetDescription dsd) throws Exception {
+	public Reader getDataset(DataSetDescription dsd) throws Exception {
 		URL url = super.getOpenmlFileUrl(dsd.getFile_id(), dsd.getName() + ".arff");
-		return new Instances(urlToStreamReader(url));
+		return urlToStreamReader(url);
 	}
 	
 	/**
-	 * Downloads a data splits file from OpenML and parses it as Instances object
+	 * Open a http connection to a openML splits file and return a file reader.
+	 * The resulting file reader can be wrapped by a Weka ArffReader. Alternatively, it can be wrapped by a Weka
+	 * Instances object, in which case the complete file will be read into memory.
 	 * 
 	 * @param task - the downloaded task object, as downloaded from openml
 	 * @return the splits file parsed as arff
@@ -49,26 +55,28 @@ public class OpenmlWekaConnector extends OpenmlConnector {
 	 * 					   parsing exception when the file id is not
 	 *                     valid arff
 	 */
-	public Instances getSplitsFromTask(Task task) throws Exception {
+	public Reader getSplitsFromTask(Task task) throws Exception {
 		URL url = TaskInformation.getEstimationProcedure(task).getData_splits_url();
-		return new Instances(urlToStreamReader(url));
+		return urlToStreamReader(url);
 	}
 	
 	/**
-	 * Downloads a file from OpenML and parses it as Instances object
+	 * Open a http connection to a openML file and return a file reader.
+	 * The resulting file reader can be wrapped by a Weka ArffReader. Alternatively, it can be wrapped by a Weka
+	 * Instances object, in which case the complete file will be read into memory.
 	 * 
 	 * @param fileId - the openml file id
-	 * @return the file parsed as arff
+	 * @return a file reader
 	 * @throws Exception - Can be various things, but most notably a 
 	 * 					   parsing exception when the file id is not
 	 *                     valid arff
 	 */
-	public Instances getArffFromUrl(int fileId) throws Exception {
+	public Reader getArffFromUrl(int fileId) throws Exception {
 		URL url = super.getOpenmlFileUrl(fileId, fileId + ".arff");
-		return new Instances(urlToStreamReader(url));
+		return urlToStreamReader(url);
 	}
 
-	private static InputStreamReader urlToStreamReader(URL url) throws IOException {
+	private static Reader urlToStreamReader(URL url) throws IOException {
 		HttpURLConnection urlConnection = (HttpURLConnection) (url.openConnection());
 		urlConnection.setInstanceFollowRedirects(true);
 		urlConnection.setConnectTimeout(1000);
@@ -76,6 +84,6 @@ public class OpenmlWekaConnector extends OpenmlConnector {
 		urlConnection.connect();
 		int responseCode = urlConnection.getResponseCode();
 		Conversion.log("OK", "URL", "HTTP request status code [" + responseCode + "] URL [" + url + "]");
-		return new InputStreamReader(urlConnection.getInputStream());
+		return new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
 	}
 }

--- a/src/test/java/openmlweka/TestDataSplits.java
+++ b/src/test/java/openmlweka/TestDataSplits.java
@@ -47,8 +47,8 @@ public class TestDataSplits extends BaseTestFramework {
 		Task task = client_read_test.taskGet(taskId);
 		EstimationProcedure ep = client_read_test.estimationProcedureGet(TaskInformation.getEstimationProcedure(task).getId());
 		DataSetDescription dsd = client_read_test.dataGet(TaskInformation.getSourceData(task).getData_set_id());
-		Instances dataset = client_read_test.getDataset(dsd);
-		Instances datasplits = client_read_test.getSplitsFromTask(task);
+		Instances dataset = new Instances(client_read_test.getDataset(dsd));
+		Instances datasplits = new Instances(client_read_test.getSplitsFromTask(task));
 		DataSplits ds = new DataSplits(dsd.getId(), ep, dataset, datasplits);
 		
 		assertTrue(ds.REPEATS * ds.FOLDS > 0);

--- a/src/test/java/openmlweka/TestVariousEstimationProcedures.java
+++ b/src/test/java/openmlweka/TestVariousEstimationProcedures.java
@@ -34,7 +34,7 @@ public class TestVariousEstimationProcedures extends BaseTestFramework {
 		assertTrue(r.getOutputFileAsMap().size() == 2);
 		
 		int fileId = r.getOutputFileAsMap().get("predictions").getFileId();
-		Instances predictions = client_read_test.getArffFromUrl(fileId);
+		Instances predictions = new Instances(client_read_test.getArffFromUrl(fileId));
 		
 		Set<String> expectedAttributes = new TreeSet<String>(Arrays.asList(CONSTANT_ATTRIBUTES));
 		if (task.getTask_type_id() == 3) {


### PR DESCRIPTION
See https://github.com/openml/EvaluationEngine/pull/39 for the reasoning behind this PR.